### PR TITLE
Set loadpath correctly for OS X Framework.

### DIFF
--- a/libopenal-racket.rkt
+++ b/libopenal-racket.rkt
@@ -12,8 +12,12 @@
                      define-listener-prop
                      define-buffer-prop))
 
+(define libopenal-path
+        (if (equal? (system-type) 'macosx)
+            "System/Library/Frameworks/OpenAL.framework/OpenAL"
+            "libopenal"))
 (define libopenal
-  (ffi-lib "libopenal"))
+  (ffi-lib libopenal-path))
 
 (define-ffi-definer define/native libopenal)
 


### PR DESCRIPTION
Self-explanatory. Make sure test this patch didn't kill things on other Unices.
