### PR TITLE
Remove bold formatting from Scribble title

### DIFF
--- a/doc/libopenal-racket.scrbl
+++ b/doc/libopenal-racket.scrbl
@@ -2,7 +2,7 @@
 @(require (for-label racket)
           (for-label "../main.rkt"))
 
-@title{@bold{OpenAL}: Bindings for the OpenAL sound library}
+@title{OpenAL: Bindings for the OpenAL sound library}
 @author{gcr}
 
 @(define openal-programmers-guide


### PR DESCRIPTION
For visual consistency with other packages within the docs