### PR TITLE
Update libopenal-racket.scrbl, fixed documentation error in the first example.

### DIFF
--- a/doc/libopenal-racket.scrbl
+++ b/doc/libopenal-racket.scrbl
@@ -25,7 +25,7 @@ bytestring.
 
 @codeblock{
 #lang racket
-(require libopenal/racket)
+(require libopenal-racket)
 
 ;; Our sound data
 (define sinewave


### PR DESCRIPTION
Fixed documentation error in the first example.
Library erroneously required as libopenal/racket instead of the correct libopenal-racket.