### PR TITLE
Update libopenal-racket.rkt, Windows openal is always OpenAL32

### DIFF
--- a/libopenal-racket.rkt
+++ b/libopenal-racket.rkt
@@ -18,8 +18,7 @@
   (cond [(equal? (system-type) 'macosx)
          "System/Library/Frameworks/OpenAL.framework/OpenAL"]
         [(equal? (system-type) 'unix) "libopenal"]
-        [(equal? (system-type) 'windows)
-         (format "OpenAL~a" (system-type 'word))]))
+        [(equal? (system-type) 'windows) "OpenAL32"]))
 (define libopenal
   (ffi-lib libopenal-path))
 


### PR DESCRIPTION
Windows openal and openal-soft dll is always called OpenAL32, even on 64 bit installs.

See https://openal-soft.org/openal-binaries/openal-soft-1.23.1-bin.zip
and
https://www.openal.org/downloads/oalinst.zip